### PR TITLE
Nexmo to Vonage renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Use Nexmo Number Insights with PHP
+# Use Vonage Number Insights with PHP
 
 This is a very simple demo app showing the [Number Insights API](https://developer.nexmo.com/number-insight/overview) in action.
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "require": {
-        "nexmo/client": "^2.0",
         "slim/slim": "^4.5",
         "slim/psr7": "^1.1",
-        "slim/php-view": "^3.0"
+        "slim/php-view": "^3.0",
+        "vonage/client": "^2.3"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b56db636380250272af80805fdf8a0ea",
+    "content-hash": "330c3a48bd602dbc6f85b06175f2e654",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -249,16 +249,16 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.3.1",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "2ffc7cc816f6207b27923ee15edf6fac668390aa"
+                "reference": "2580100a0d798c4452e9351847febdf76352130c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/2ffc7cc816f6207b27923ee15edf6fac668390aa",
-                "reference": "2ffc7cc816f6207b27923ee15edf6fac668390aa",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/2580100a0d798c4452e9351847febdf76352130c",
+                "reference": "2580100a0d798c4452e9351847febdf76352130c",
                 "shasum": ""
             },
             "require": {
@@ -288,10 +288,6 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3.x-dev",
-                    "dev-develop": "2.4.x-dev"
-                },
                 "laminas": {
                     "config-provider": "Laminas\\Diactoros\\ConfigProvider",
                     "module": "Laminas\\Diactoros"
@@ -339,7 +335,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-07-07T15:34:31+00:00"
+            "time": "2020-09-02T13:59:41+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -401,16 +397,16 @@
         },
         {
             "name": "lcobucci/jwt",
-            "version": "3.3.2",
+            "version": "3.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "56f10808089e38623345e28af2f2d5e4eb579455"
+                "reference": "c1123697f6a2ec29162b82f170dd4a491f524773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/56f10808089e38623345e28af2f2d5e4eb579455",
-                "reference": "56f10808089e38623345e28af2f2d5e4eb579455",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/c1123697f6a2ec29162b82f170dd4a491f524773",
+                "reference": "c1123697f6a2ec29162b82f170dd4a491f524773",
                 "shasum": ""
             },
             "require": {
@@ -462,118 +458,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2020-05-22T08:21:12+00:00"
-        },
-        {
-            "name": "nexmo/client",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Nexmo/nexmo-php-complete.git",
-                "reference": "664082abac14f6ab9ceec9abaf2e00aeb7c17333"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Nexmo/nexmo-php-complete/zipball/664082abac14f6ab9ceec9abaf2e00aeb7c17333",
-                "reference": "664082abac14f6ab9ceec9abaf2e00aeb7c17333",
-                "shasum": ""
-            },
-            "require": {
-                "nexmo/client-core": "^2.0",
-                "php": ">=7.1",
-                "php-http/guzzle6-adapter": "^2.0"
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Tim Lytle",
-                    "email": "tim@nexmo.com",
-                    "homepage": "http://twitter.com/tjlytle",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Michael Heap",
-                    "email": "michael.heap@vonage.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Lorna Mitchell",
-                    "email": "lorna.mitchell@vonage.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP Client for using Nexmo's API.",
-            "time": "2019-08-20T16:06:03+00:00"
-        },
-        {
-            "name": "nexmo/client-core",
-            "version": "2.2.2",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:Nexmo/nexmo-php.git",
-                "reference": "1a8ccfbde765c9599973995d1eeac491f094aa0a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Nexmo/nexmo-php/zipball/1a8ccfbde765c9599973995d1eeac491f094aa0a",
-                "reference": "1a8ccfbde765c9599973995d1eeac491f094aa0a",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-diactoros": "^1.8.4 || ^2.0",
-                "lcobucci/jwt": "^3.2",
-                "ocramius/package-versions": "^1.4",
-                "php": ">=7.1",
-                "psr/container": "^1.0",
-                "psr/http-client-implementation": "^1.0"
-            },
-            "require-dev": {
-                "estahn/phpunit-json-assertions": "^3.0.0",
-                "php-http/guzzle6-adapter": "^2.0",
-                "php-http/mock-client": "^1.4",
-                "phpstan/phpstan": "^0.12.11",
-                "phpunit/phpunit": "^7.4",
-                "squizlabs/php_codesniffer": "^3.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Nexmo\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Tim Lytle",
-                    "email": "tim@nexmo.com",
-                    "homepage": "http://twitter.com/tjlytle",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Michael Heap",
-                    "email": "michael.heap@vonage.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Lorna Mitchell",
-                    "email": "lorna.mitchell@vonage.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Chris Tankersley",
-                    "email": "chris.tankersley@vonage.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "PHP Client for using Nexmo's API.",
-            "time": "2020-08-13T19:48:21+00:00"
+            "time": "2020-08-20T13:22:28+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -1837,6 +1722,167 @@
                 }
             ],
             "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
+            "name": "vonage/client",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Vonage/vonage-php-sdk.git",
+                "reference": "e9c1492a9f1572124143e6fa963da417bb20d9ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Vonage/vonage-php-sdk/zipball/e9c1492a9f1572124143e6fa963da417bb20d9ae",
+                "reference": "e9c1492a9f1572124143e6fa963da417bb20d9ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "php-http/guzzle6-adapter": "^2.0",
+                "vonage/client-core": "^2.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Lytle",
+                    "email": "tim@nexmo.com",
+                    "homepage": "http://twitter.com/tjlytle",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Michael Heap",
+                    "email": "michael.heap@vonage.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Lorna Mitchell",
+                    "email": "lorna.mitchell@vonage.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Chris Tankersley",
+                    "email": "chris.tankersley@vonage.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Client for using Vonage's API.",
+            "time": "2020-08-24T14:20:39+00:00"
+        },
+        {
+            "name": "vonage/client-core",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Vonage/vonage-php-sdk-core.git",
+                "reference": "c4e31194a1681211bdca7439b87be021999b82a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Vonage/vonage-php-sdk-core/zipball/c4e31194a1681211bdca7439b87be021999b82a9",
+                "reference": "c4e31194a1681211bdca7439b87be021999b82a9",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-diactoros": "^1.8.4 || ^2.0",
+                "lcobucci/jwt": "^3.2",
+                "ocramius/package-versions": "^1.4",
+                "php": ">=7.1",
+                "psr/container": "^1.0",
+                "psr/http-client-implementation": "^1.0",
+                "vonage/nexmo-bridge": "^0.1.0"
+            },
+            "require-dev": {
+                "estahn/phpunit-json-assertions": "^3.0.0",
+                "php-http/guzzle6-adapter": "^2.0",
+                "php-http/mock-client": "^1.4",
+                "phpstan/phpstan": "^0.12.11",
+                "phpunit/phpunit": "^7.4",
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Vonage\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Lytle",
+                    "email": "tim@nexmo.com",
+                    "homepage": "http://twitter.com/tjlytle",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Michael Heap",
+                    "email": "michael.heap@vonage.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Lorna Mitchell",
+                    "email": "lorna.mitchell@vonage.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Chris Tankersley",
+                    "email": "chris.tankersley@vonage.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Client for using Vonage's API.",
+            "time": "2020-09-02T19:49:09+00:00"
+        },
+        {
+            "name": "vonage/nexmo-bridge",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nexmo/vonage-php-nexmo-bridge.git",
+                "reference": "62653b1165f4401580ca8d2b859f59c968de3711"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nexmo/vonage-php-nexmo-bridge/zipball/62653b1165f4401580ca8d2b859f59c968de3711",
+                "reference": "62653b1165f4401580ca8d2b859f59c968de3711",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.39",
+                "phpunit/phpunit": "^7.4",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Vonage\\NexmoBridge\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Tankersley",
+                    "email": "chris.tankersley@vonage.com"
+                }
+            ],
+            "description": "Provides a bridge for using the Vonage PHP SDK with the older Nexmo namespace",
+            "time": "2020-08-25T02:50:42+00:00"
         }
     ],
     "packages-dev": [],

--- a/config.php.sample
+++ b/config.php.sample
@@ -2,7 +2,7 @@
 
 // Copy config.php.sample to config.php and edit it as required
 
-// sign up for a Nexmo account here: https://dashboard.nexmo.com
+// sign up for a Vonage account here: https://dashboard.nexmo.com
 $config['api_key'] = "";
 $config['api_secret'] = "";
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,6 @@
 <?php
 
-use Nexmo\Client\Exception\Request as NexmoRequestException;
+use Vonage\Client\Exception\Request as VonageRequestException;
 use \Psr\Http\Message\ServerRequestInterface as Request;
 use \Psr\Http\Message\ResponseInterface as Response;
 use Slim\Factory\AppFactory;
@@ -20,11 +20,11 @@ $app->post('/insight', function (Request $request, Response $response) use ($vie
     try {
         $params = $request->getParsedBody();
 
-        $basic = new \Nexmo\Client\Credentials\Basic(
+        $basic = new \Vonage\Client\Credentials\Basic(
             $config['api_key'],
             $config['api_secret']
         );
-        $client = new \Nexmo\Client($basic);
+        $client = new \Vonage\Client($basic);
 
         // choose the correct insight type
         switch ($params['insight']) {
@@ -40,7 +40,7 @@ $app->post('/insight', function (Request $request, Response $response) use ($vie
         }
 
         return $view->render($response, 'main.php', ['insight' => $insight]);
-    } catch (NexmoRequestException $requestError) {
+    } catch (VonageRequestException $requestError) {
         return $view->render(
             $response, 
             'main.php', 

--- a/templates/main.php
+++ b/templates/main.php
@@ -2,14 +2,26 @@
 
 // at the top of a template is a shockingly lazy place to declare this
 function show($data, $field) {
+    $propertyMap = [
+        'country_code' => 'getCountryCode',
+        'country_name' => 'getCountryName',
+        'national_format_number' => 'getNationalFormatNumber',
+        'international_format_number' => 'getInternationalFormatNumber',
+        'valid_number' => 'getValidNumber',
+        'reachable' => 'getReachable',
+        'remaining_balance' => 'getRemainingBalance'
+    ];
+
     $output = "";
-    if(isset($data[$field])) {
+
+    if(method_exists($data, $propertyMap[$field])) {
         $output .= "<tr><td>";
         $output .= $field;
         $output .= "</td><td>";
-        $output .= $data[$field];
+        $output .= call_user_func(array($data, $propertyMap[$field]));
         $output .= "</td><tr>\n";
     }
+
     return $output;
 }
 ?>
@@ -87,13 +99,13 @@ function show($data, $field) {
                     echo "<p>\n";
                     echo "<table class=\"pure-table pure-table-striped\">\n";
                     echo "<td><b>Field</b></td><td><b>Value</b></td>";
-                    echo show($insight,'country_code');
-                    echo show($insight,'country_name');
-                    echo show($insight,'national_format_number');
-                    echo show($insight,'international_format_number');
-                    echo show($insight,'valid_number');
-                    echo show($insight,'reachable');
-                    echo show($insight,'remaining_balance');
+                    echo show($insight, 'country_code');
+                    echo show($insight, 'country_name');
+                    echo show($insight, 'national_format_number');
+                    echo show($insight, 'international_format_number');
+                    echo show($insight, 'valid_number');
+                    echo show($insight, 'reachable');
+                    echo show($insight, 'remaining_balance');
                     echo "</table>\n";
                     echo "</p>\n";
 


### PR DESCRIPTION
Further changes to this code sample, to use the new `vonage/client` package rather than `nexmo/client`. Also replacing the Nexmo namespaces with Vonage namespaces.

As a result of the SDK moving towards using class methods to retrieve API response values instead of array values I've also updated these with a map.