### PR TITLE
Replaced Synchronous Advanced Number Insight with Asynchronous Advanced Number Insight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/*
 config.php
 private.key
+public/advanced-insight-response.txt

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a very simple demo app showing the [Number Insights API](https://develop
 
 First: install dependencies `composer install`
 
-Then: in your Terminal run: `ngrok http 8000`
+Then: in your Terminal run: `ngrok http 8080`
 
 Then: copy `config.php.sample` to `config.php`. Edit the variables to be your Vonage API key, Vonage API secret, and your Ngrok forwarding URL found in the output form the above command. Your Vonage API key and secret is available from the [dashboard](http://dashboard.nexmo.com), where you can also sign up there too if you don't have an account).
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a very simple demo app showing the [Number Insights API](https://develop
 
 First: install dependencies `composer install`
 
-Then: copy `config.php.sample` to `config.php` and edit to add your key and secret (available from the [dashboard](http://dashboard.nexmo.com) and you can sign up there too if you don't have an account).
+Then: in your Terminal run: `ngrok http 8000`
+
+Then: copy `config.php.sample` to `config.php`. Edit the variables to be your Vonage API key, Vonage API secret, and your Ngrok forwarding URL found in the output form the above command. Your Vonage API key and secret is available from the [dashboard](http://dashboard.nexmo.com), where you can also sign up there too if you don't have an account).
 
 Finally: change into the `public/` directory and start the webserver with `php -S localhost:8080`

--- a/config.php.sample
+++ b/config.php.sample
@@ -5,4 +5,4 @@
 // sign up for a Vonage account here: https://dashboard.nexmo.com
 $config['api_key'] = "";
 $config['api_secret'] = "";
-
+$config['callback_url'] = "";

--- a/public/css/marketing.css
+++ b/public/css/marketing.css
@@ -25,8 +25,11 @@ label {
 }
 
 a {
-    color: #ffffff
+    color: #ffffff;
+}
 
+.async-response-link {
+    color: #2d3e50;
 }
 
 .pure-img-responsive {

--- a/public/index.php
+++ b/public/index.php
@@ -26,20 +26,34 @@ $app->post('/insight', function (Request $request, Response $response) use ($vie
         );
         $client = new \Vonage\Client($basic);
 
+        $isAsyncRequest = false;
+
         // choose the correct insight type
         switch ($params['insight']) {
             case 'standard':
                 $insight = $client->insights()->standard($params['number']);
                 break;
             case 'advanced':
-                $insight = $client->insights()->advanced($params['number']);
+                $isAsyncRequest = true;
+                $insight = $client->insights()->advancedAsync(
+                    $params['number'],
+                    $config['callback_url'] . '/webhook/number-insight'
+                );
                 break;
             default:
                 $insight = $client->insights()->basic($params['number']);
                 break;
         }
 
-        return $view->render($response, 'main.php', ['insight' => $insight]);
+        return $view->render(
+            $response,
+            'main.php',
+            [
+                'insight' => $insight,
+                'isAsyncRequest' => $isAsyncRequest,
+                'error' => false
+            ]
+        );
     } catch (VonageRequestException $requestError) {
         return $view->render(
             $response, 
@@ -47,10 +61,20 @@ $app->post('/insight', function (Request $request, Response $response) use ($vie
             [
                 'error' => true, 
                 'error_message' => $requestError->getMessage(),
-                'insight' => $insight
+                'insight' => $insight,
+                'isAsyncRequest' => $isAsyncRequest
             ]
         );
     }
+});
+
+$app->post('/webhook/number-insight', function (Request $request, Response $response) {
+    $outputFile = fopen('advanced-insight-response.txt', 'a');
+
+    fwrite($outputFile, $request->getBody());
+    fclose($outputFile);
+
+    return $response;
 });
 
 $app->run();

--- a/public/index.php
+++ b/public/index.php
@@ -61,8 +61,6 @@ $app->post('/insight', function (Request $request, Response $response) use ($vie
             [
                 'error' => true, 
                 'error_message' => $requestError->getMessage(),
-                'insight' => $insight,
-                'isAsyncRequest' => $isAsyncRequest
             ]
         );
     }

--- a/public/index.php
+++ b/public/index.php
@@ -67,7 +67,7 @@ $app->post('/insight', function (Request $request, Response $response) use ($vie
 });
 
 $app->post('/webhook/number-insight', function (Request $request, Response $response) {
-    $outputFile = fopen('advanced-insight-response.txt', 'a');
+    $outputFile = fopen('advanced-insight-response.txt', 'w');
 
     fwrite($outputFile, $request->getBody());
     fclose($outputFile);

--- a/templates/main.php
+++ b/templates/main.php
@@ -109,9 +109,9 @@ function show($data, $field) {
                     echo "</table>\n";
                     echo "</p>\n";
 
-                elseif ($isAsyncRequest): ?>
+                elseif (isset($isAsyncRequest) && $isAsyncRequest): ?>
                     <p>
-                        An Asynchronous request was made. Please check your server logs for the inbound Advanced Asynchronous response.
+                        An Asynchronous request was made. Please check <a class="async-response-link" href="advanced-insight-response.txt" target="_blank">the advanced-insight-response.txt file</a> for the inbound Advanced Asynchronous response.
                     </p>
 
                 <?php else: ?>

--- a/templates/main.php
+++ b/templates/main.php
@@ -95,7 +95,7 @@ function show($data, $field) {
 
             <div class="l-box-lrg pure-u-1 pure-u-md-3-5">
                 <h4>Phone number insights</h4>
-                <?php if($insight):
+                <?php if($insight && !$isAsyncRequest):
                     echo "<p>\n";
                     echo "<table class=\"pure-table pure-table-striped\">\n";
                     echo "<td><b>Field</b></td><td><b>Value</b></td>";
@@ -109,10 +109,15 @@ function show($data, $field) {
                     echo "</table>\n";
                     echo "</p>\n";
 
-                else: ?>
-                <p>
-                    Use our Number Insights API to get inside information on a phone number and its status.
-                </p>
+                elseif ($isAsyncRequest): ?>
+                    <p>
+                        An Asynchronous request was made. Please check your server logs for the inbound Advanced Asynchronous response.
+                    </p>
+
+                <?php else: ?>
+                    <p>
+                        Use our Number Insights API to get inside information on a phone number and its status.
+                    </p>
 
                 <?php endif; ?>
             </div>


### PR DESCRIPTION
Because the synchronous advanced number insight has been deprecated and is unreliable, I've replaced this functionality with the asynchronous advanced number insights. Which requires another endpoint and a place to store the returned response from the webhook.
